### PR TITLE
Remove warning that input 2 is not supported for Philips wall switch

### DIFF
--- a/docs/devices/929003017102.md
+++ b/docs/devices/929003017102.md
@@ -44,7 +44,6 @@ Notes:
 - This device does not support direct binding (to a device instead of a group).
 - After doing this, the power events are still sent and can hence be used for automation.
 - Pressing the yellow reconfigure button in the *About* tab will reset the bindings of the coordinator, but it will not unbind any groups - they have to be unbound explicitly.
-- Actions are only sent for input 1 of the device. For input 2 no actions will be sent (so a double rocker is **not** supported).
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
It works out of the box for me with Z2M 1.39.1 and firmware version 1.0.3 (build date 20210115). I did click on "dual_rocker" before recording the GIF, not sure if that had an impact (when going back to the "Exposes" tab in the recording, it no longer displays which device mode is enabled).

![2022-08-17 Philips Hue wall switch both inputs work](https://github.com/user-attachments/assets/39d68add-1963-4a2f-bab6-89b8fd5f48a6)

Also I've edited the GIF, pausing on the frames where the action is visible. In real life the transitions are much faster.